### PR TITLE
Add pre-commit support

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,20 +1,12 @@
 #!/bin/sh
 
 changed_cr_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.cr$')
-[ -z "$changed_cr_files" ] #&& exit 0
+[ -z "$changed_cr_files" ] && exit 0
 
-crystal tool format --check $changed_cr_files >/dev/null
-ret_code=$?
+crystal tool format $changed_cr_files
 
-if [ 0 -ne $ret_code ]; then
-  echo "Files need formatting. Use \`crystal tool format\` and recommit."
-  exit $ret_code
-fi
+shards check || exit 1
 
-crystal spec --fail-fast >/dev/null
-ret_code=$?
+bin/ameba -f flycheck $changed_cr_files || exit 1
 
-if [ 0 -ne $ret_code ]; then
-  echo "Specs failed. Ensure specs pass and recommit."
-  exit $ret_code
-fi
+crystal spec --fail-fast >/dev/null || echo "Specs failed."; exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+changed_cr_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.cr$')
+[ -z "$changed_cr_files" ] #&& exit 0
+
+crystal tool format --check $changed_cr_files >/dev/null
+ret_code=$?
+
+if [ 0 -ne $ret_code ]; then
+  echo "Files need formatting. Use \`crystal tool format\` and recommit."
+  exit $ret_code
+fi
+
+crystal spec --fail-fast >/dev/null
+ret_code=$?
+
+if [ 0 -ne $ret_code ]; then
+  echo "Specs failed. Ensure specs pass and recommit."
+  exit $ret_code
+fi

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Beautify.css(css_content)
 
 ## Contributing
 
+There is a provided [githook](https://githooks.com/) that will check code formatting and specs before commiting. You can run `make init` or `git config core.hooksPath .githooks` to use this.
+
 1. Fork it (<https://github.com/Daniel-Worrall/beautify/fork>)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)

--- a/makefile
+++ b/makefile
@@ -1,0 +1,2 @@
+init:
+	git config core.hooksPath .githooks


### PR DESCRIPTION
Note: `crystal spec --fail-fast` is currently not returning an error code but should be fixed in Crystal 0.32.0